### PR TITLE
[10.0][CHG] get static xml templates using post method over get

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -510,7 +510,7 @@ class WebClient(http.Controller):
         headers = [('Content-Type', 'application/javascript'), ('Cache-Control', 'max-age=%s' % (36000))]
         return request.make_response(momentjs_locale, headers)
 
-    @http.route('/web/webclient/qweb', type='http', auth="none", cors="*")
+    @http.route('/web/webclient/qweb', type='http', auth="none", methods=['GET', 'POST'], cors="*", csrf=False)
     def qweb(self, mods=None, db=None):
         files = [f[0] for f in manifest_glob('qweb', addons=mods, db=db)]
         last_modified = get_last_modified(files)

--- a/addons/web/static/src/js/framework/session.js
+++ b/addons/web/static/src/js/framework/session.js
@@ -237,7 +237,9 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
     },
     load_qweb: function(mods) {
         this.qweb_mutex.exec(function () {
-            return $.get('/web/webclient/qweb?mods=' + mods).then(function (doc) {
+            return $.post('/web/webclient/qweb', {
+                mods: mods
+            }).then(function (doc) {
                 if (!doc) { return; }
                 qweb.add_template(doc);
             });


### PR DESCRIPTION
Intended to be used in a gitaggregate for now.
Do not merge.

Before this commit, the webclient retrieved static xml templates using a get http method. This was causing problem with a firewall as it was breaking some security rules. Indeed, depending on the amount of module having xml templates, the request might be very long as all the modules names were concatenated in a get request.

This commit simply changes this behavior to use a post method.