### PR TITLE
[DON'T MERGE][12.0] - prevent concurrent on mass mailing

### DIFF
--- a/addons/mass_mailing/models/mass_mailing.py
+++ b/addons/mass_mailing/models/mass_mailing.py
@@ -988,7 +988,8 @@ class MassMailing(models.Model):
             # auto-commit except in testing mode
             auto_commit = not getattr(threading.currentThread(), 'testing', False)
             composer.send_mail(auto_commit=auto_commit)
-            mailing.write({'state': 'done', 'sent_date': fields.Datetime.now()})
+            if not self.env.context.get('default_marketing_activity_id', False):
+                mailing.write({'state': 'done', 'sent_date': fields.Datetime.now()})
         return True
 
     def convert_links(self):


### PR DESCRIPTION
in case we would manage mass mailing in queue job and send email one by one in channel with capacity higher than 1, the write cause concurrency issue 