### PR TITLE
Init comodel_name on relational fields from generic type's arg

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -16,6 +16,7 @@ import enum
 import itertools
 import json
 import logging
+import typing
 import uuid
 import warnings
 from typing import Any, TypeVar, Generic
@@ -2770,6 +2771,18 @@ class _Relational(Generic[_T], Field[_T]):
             return super().__get__(records, owner)
         # multirecord case: use mapped
         return self.mapped(records)
+
+    def setup(self, model):
+        if not self.comodel_name:
+            # Auto initialize the comodel name from the generic type's var if used
+            # This allows to get the comodel from the type when the field is declared
+            # as `partner = fields.Many2one[Partner]()`
+            type_args = typing.get_args(getattr(self, "__orig_class__", None))
+            if type_args and issubclass(type_args[0], BaseModel):
+                self.comodel_name = type_args[0]._name
+            # TODO We could error out if the comodel attribute is set and is
+            # incompatible with the type.
+        return super().setup(model)
 
     def setup_nonrelated(self, model):
         super().setup_nonrelated(model)


### PR DESCRIPTION
This change allows to take advantage of field descriptors on relational fields to initialize the comodel_name from optional type's arg that can be specified on field declaration. With this change, this kind of syntax becomes valid and will avoid errors in the comodel_name args.

`partner = fields.Many2one[Partner]()`

This code is not part of the _Relational class constructor since we need to get access to the `__orig_class__` attribute which is set on the instance by the Generic metaclass after the call to the _Relational class constructor.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
