### PR TITLE
Take into account FrowardRef when computing the comodel_name

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -16,10 +16,11 @@ import enum
 import itertools
 import json
 import logging
+import re
 import typing
 import uuid
 import warnings
-from typing import Any, TypeVar, Generic
+from typing import Any, TypeVar, Generic, ForwardRef
 
 _T = TypeVar("_T", bound=Any)
 
@@ -59,6 +60,10 @@ _schema = logging.getLogger(__name__[:-7] + '.schema')
 
 NoneType = type(None)
 Default = object()                      # default value for __init__() methods
+
+
+def camel_case_to_dot_case(name):
+    return re.sub(r"(?<!^)(?=[A-Z])", ".", name).lower()
 
 
 def first(records):
@@ -2778,8 +2783,11 @@ class _Relational(Generic[_T], Field[_T]):
             # This allows to get the comodel from the type when the field is declared
             # as `partner = fields.Many2one[Partner]()`
             type_args = typing.get_args(getattr(self, "__orig_class__", None))
-            if type_args and issubclass(type_args[0], BaseModel):
-                self.comodel_name = type_args[0]._name
+            if type_args:
+                if type_args[0].__class__ == ForwardRef:
+                    self.comodel_name = camel_case_to_dot_case(type_args[0].__forward_arg__)
+                elif  issubclass(type_args[0], BaseModel):
+                    self.comodel_name = type_args[0]._name
             # TODO We could error out if the comodel attribute is set and is
             # incompatible with the type.
         return super().setup(model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ pyusb==1.0.2
 qrcode==6.1
 reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
 requests==2.25.1 # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
+typing_extensions==4.4.0
 urllib3==1.26.5 # indirect / min version = 1.25.8 (Focal with security backports)
 vobject==0.9.6.1
 Werkzeug==0.16.1 ; python_version <= '3.9'


### PR DESCRIPTION
To avoid circular import it's common to reference a type as a string for generics:

```python
from odoo import models, fields

from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from .res_partner import Partner as ResPartner

class Thing(models.Model):

    _name = "thing"
    _description = "Thing"

    partner_id = fields.Many2one["ResPartner"]()

```

In such a case, the type's arg at runtime is not a class but an instance of typing.ForwadRef. In such a case, the comodel_name is computed by converting the classname provided by te ForwardRef from CamelCase to dot.case
