### PR TITLE
[18.0][DO NOT MERGE] - disable l10n_be and l10n_es demo data

### DIFF
--- a/addons/l10n_be/__manifest__.py
+++ b/addons/l10n_be/__manifest__.py
@@ -48,7 +48,7 @@ Wizards provided by this module:
         'data/menuitem_data.xml',
     ],
     'demo': [
-        'demo/demo_company.xml',
+        # 'demo/demo_company.xml',
     ],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_es/__manifest__.py
+++ b/addons/l10n_es/__manifest__.py
@@ -50,8 +50,8 @@ Spanish charts of accounts (PGCE 2008).
         'data/mod420.xml',
     ],
     'demo': [
-        'demo/demo_company.xml',
-        'demo/demo_partner.xml',
+        # 'demo/demo_company.xml',
+        # 'demo/demo_partner.xml',
     ],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_es_edi_facturae/__manifest__.py
+++ b/addons/l10n_es_edi_facturae/__manifest__.py
@@ -34,7 +34,7 @@ for more informations, see https://www.facturae.gob.es/face/Paginas/FACE.aspx
         'wizard/account_move_reversal_view.xml',
     ],
     'demo': [
-        'demo/l10n_es_edi_facturae_demo.xml',
+        # 'demo/l10n_es_edi_facturae_demo.xml',
     ],
     'post_init_hook': '_l10n_es_edi_facturae_post_init_hook',
     'installable': True,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  Avoid error loading l10n_be and l10n_es demo data in PRG pipelines

Current behavior before PR:  Error loading l10n_be and l10n_es demo data in PRG pipelines

Desired behavior after PR is merged:  No error in PRG pipelines  regarding  l10n_be and l10n_es demo data



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
