### PR TITLE
[18.0][DON'T MERGE] peppol: no eas check

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1051,13 +1051,24 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     "The VAT number of the supplier does not seem to be valid. It should be of the form: NO179728982MVA."
                 ) if not mva.is_valid(vat) or len(vat) != 14 or vat[:2] != 'NO' or vat[-3:] != 'MVA' else "",
             })
-
         if vals['supplier'].country_id.code == 'BE' and vals['supplier'].company_registry:
             if not be_vat.is_valid(vals['supplier'].company_registry):
                 constraints.update({
                     'PEPPOL-COMMON-R043_supplier': _('%s should have a valid KBO/BCE number in the Company ID field', vals['supplier'].display_name),
                 })
-
+        # # [PEPPOL-EN16931-R010]
+        # if not vals['document_node']['cac:AccountingCustomerParty']['cac:Party']['cbc:EndpointID']['_text']:
+        #     constraints['ubl_peppol_en16931-r010'] = _(
+        #         "[PEPPOL-EN16931-R010] An electronic address (EAS) must be provided on the customer '%s'.",
+        #         vals['customer'].display_name,
+        #     )
+        #
+        # # [PEPPOL-EN16931-R020]
+        # if not vals['document_node']['cac:AccountingSupplierParty']['cac:Party']['cbc:EndpointID']['_text']:
+        #     constraints['ubl_peppol_en16931-r020'] = _(
+        #         "[PEPPOL-EN16931-R020] An electronic address (EAS) must be provided on the company '%s'.",
+        #         vals['supplier'].display_name,
+        #     )
         if vals['customer'].country_id.code == 'BE' and vals['customer'].company_registry:
             if not be_vat.is_valid(vals['customer'].company_registry):
                 constraints.update({


### PR DESCRIPTION
this commit, introduced a week ago, prevents invoice generation if the customer doesn't have an EAS configured
this blocks invoicing for customers who are not on Peppol and use email as the sending method

a helpdesk ticket was created (5944854)