### PR TITLE
[18.0][DON'T MERGE][IMP] sale_pdf_quote_builder: use documents

### DIFF
--- a/addons/sale_pdf_quote_builder/__manifest__.py
+++ b/addons/sale_pdf_quote_builder/__manifest__.py
@@ -13,6 +13,7 @@
         'security/ir.model.access.csv',
         'security/ir_rules.xml',
 
+        'views/ir_actions_report.xml',
         'views/product_document_views.xml',
         'views/quotation_document_views.xml',
         'views/sale_order_template_views.xml',

--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -4,7 +4,7 @@ import base64
 import io
 import json
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.tools import format_amount, format_date, format_datetime, pdf
 from odoo.tools.pdf import PdfFileWriter, PdfFileReader, NameObject, NumberObject, createStringObject
 
@@ -12,10 +12,13 @@ from odoo.tools.pdf import PdfFileWriter, PdfFileReader, NameObject, NumberObjec
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
+    use_documents = fields.Boolean(help="Add quotation and product documents (headers and footers) to this report.")
+
     def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):
         """Override to add and fill headers, footers and product documents to the sale quotation."""
         result = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
-        if self._get_report(report_ref).report_name != 'sale.report_saleorder':
+        report = self._get_report(report_ref)
+        if not (report.use_documents and report.model == "sale.order"):
             return result
 
         orders = self.env['sale.order'].browse(res_ids)

--- a/addons/sale_pdf_quote_builder/report/ir_actions_report.xml
+++ b/addons/sale_pdf_quote_builder/report/ir_actions_report.xml
@@ -14,6 +14,7 @@
 
     <record id="sale.action_report_saleorder" model="ir.actions.report">
         <field name="name">PDF Quote</field>
+        <field name="use_documents">1</field>
     </record>
 
 </odoo>

--- a/addons/sale_pdf_quote_builder/views/ir_actions_report.xml
+++ b/addons/sale_pdf_quote_builder/views/ir_actions_report.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="act_report_xml_view_inherit_sale_pdf_quote_builder" model="ir.ui.view">
+        <field name="name">ir.actions.report.form.pdf.quote.builder</field>
+        <field name="model">ir.actions.report</field>
+        <field name="inherit_id" ref="base.act_report_xml_view"/>
+        <field name="arch" type="xml">
+            <page name="advanced" position="inside">
+                <group>
+                    <field name="use_documents" invisible="model != 'sale.order'" />
+                </group>
+            </page>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Allow other sale report than the default one to use quotation documents.
